### PR TITLE
Enable the use of ssh-rsa keys

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -28,6 +28,7 @@ PrintLastLog                    no
 # Allow pubkey auth, without PAM support
 PubkeyAuthentication            yes
 AuthenticationMethods           publickey
+PubkeyAcceptedAlgorithms        +ssh-rsa
 UsePAM                          no
 
 # Explicitely disable everything else


### PR DESCRIPTION
My infrastructure has a lot of RSA keys that we still need to use.